### PR TITLE
[Feature] 자기소개 섹션 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "next": "15.4.5",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-icons": "^5.5.0",
+        "react-toastify": "^11.0.5",
         "zustand": "^5.0.7"
       },
       "devDependencies": {
@@ -7508,12 +7510,34 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "next": "15.4.5",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-icons": "^5.5.0",
+    "react-toastify": "^11.0.5",
     "zustand": "^5.0.7"
   },
   "devDependencies": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,9 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 
 import "@/styles/global.css";
+import "react-toastify/dist/ReactToastify.css";
+
+import ToastProvider from "@/providers/ToastProvider";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -26,7 +29,11 @@ interface RootLayoutProps {
 const RootLayout = ({ children }: Readonly<RootLayoutProps>) => {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>{children}</body>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <ToastProvider />
+
+        {children}
+      </body>
     </html>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,69 +1,13 @@
-import Image from "next/image";
+import clsx from "clsx";
 
-const Home = () => {
+import IntroductionSection from "@/components/organisms/IntroductionSection";
+
+const MainPage = () => {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image className="dark:invert" src="/next.svg" alt="Next.js logo" width={180} height={38} priority />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">src/app/page.tsx</code>.
-          </li>
-          <li className="tracking-[-.01em]">Save and see your changes instantly.</li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image className="dark:invert" src="/vercel.svg" alt="Vercel logomark" width={20} height={20} />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image aria-hidden src="/file.svg" alt="File icon" width={16} height={16} />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image aria-hidden src="/window.svg" alt="Window icon" width={16} height={16} />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image aria-hidden src="/globe.svg" alt="Globe icon" width={16} height={16} />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <main className={clsx("flex flex-col w-full max-w-screen-lg min-h-screen mx-auto px-5 items-center", "md:px-8", "lg:px-10")}>
+      <IntroductionSection />
+    </main>
   );
 };
 
-export default Home;
+export default MainPage;

--- a/src/components/animations/SlideAnimation.tsx
+++ b/src/components/animations/SlideAnimation.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { ReactNode } from "react";
+import { motion, Easing } from "framer-motion";
+
+interface SlideAnimationProps {
+  animationKey?: string;
+  offsetX?: number | string;
+  offsetY?: number | string;
+  duration?: number;
+  delay?: number;
+  ease?: Easing | Easing[];
+  children: ReactNode;
+}
+
+const SlideAnimation = ({ animationKey, offsetX = 0, offsetY = 0, duration = 0.3, delay, ease, children }: SlideAnimationProps) => {
+  return (
+    <motion.div
+      key={animationKey}
+      initial={{ opacity: 0, x: offsetX, y: offsetY }}
+      exit={{ opacity: 0, x: offsetX, y: offsetY }}
+      animate={{ opacity: 1, x: 0, y: 0 }}
+      transition={{
+        type: "tween",
+        ease,
+        duration,
+        delay,
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export default SlideAnimation;

--- a/src/components/atoms/ContactDetail.tsx
+++ b/src/components/atoms/ContactDetail.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { toast } from "react-toastify";
+import { MdContentCopy } from "react-icons/md";
+
+import Headline1 from "@/components/atoms/typography/Headline1";
+
+interface ContactDetailProps {
+  contact: string;
+}
+
+const ContactDetail = ({ contact }: ContactDetailProps) => {
+  const handleCopy = (): void => {
+    navigator.clipboard.writeText(contact);
+
+    toast.success("연락처가 복사되었습니다.");
+  };
+
+  return (
+    <div className="flex items-center gap-1">
+      <Headline1 text={contact} />
+
+      <MdContentCopy className="cursor-pointer" onClick={handleCopy} />
+    </div>
+  );
+};
+
+export default ContactDetail;

--- a/src/components/molecules/ContactGroup.tsx
+++ b/src/components/molecules/ContactGroup.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { useState } from "react";
+import clsx from "clsx";
+import { AnimatePresence } from "framer-motion";
+import { BsFillTelephoneFill } from "react-icons/bs";
+import { MdEmail } from "react-icons/md";
+import { FaGithub } from "react-icons/fa";
+
+import SlideAnimation from "@/components/animations/SlideAnimation";
+import ContactDetail from "@/components/atoms/ContactDetail";
+
+const ContactGroup = () => {
+  const [activeContact, setActiveContact] = useState<"tel" | "email" | null>(null);
+
+  const toggleTel = (): void => {
+    setActiveContact((prev) => (prev === "tel" ? null : "tel"));
+  };
+
+  const toggleEmail = (): void => {
+    setActiveContact((prev) => (prev === "email" ? null : "email"));
+  };
+
+  return (
+    <div className="flex flex-col items-center w-full gap-4">
+      <div className="flex gap-10">
+        <BsFillTelephoneFill
+          className={clsx("cursor-pointer", activeContact === "tel" && "text-primary-600")}
+          size={32}
+          onClick={toggleTel}
+        />
+
+        <MdEmail className={clsx("cursor-pointer", activeContact === "email" && "text-primary-600")} size={32} onClick={toggleEmail} />
+
+        <a href="https://github.com/ggalmury">
+          <FaGithub size={32} />
+        </a>
+      </div>
+
+      <AnimatePresence mode="wait">
+        {activeContact === "tel" && (
+          <SlideAnimation animationKey="tel" offsetY={-20} ease="backOut">
+            <ContactDetail contact="010-7199-7957" />
+          </SlideAnimation>
+        )}
+
+        {activeContact === "email" && (
+          <SlideAnimation animationKey="email" offsetY={-20} ease="backOut">
+            <ContactDetail contact="leejaeyun0922@gmail.com" />
+          </SlideAnimation>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+};
+
+export default ContactGroup;

--- a/src/components/organisms/IntroductionSection.tsx
+++ b/src/components/organisms/IntroductionSection.tsx
@@ -1,0 +1,44 @@
+import SlideAnimation from "@/components/animations/SlideAnimation";
+import Display1 from "@/components/atoms/typography/Display1";
+import Title1 from "@/components/atoms/typography/Title1";
+import Heading1 from "@/components/atoms/typography/Heading1";
+import ContactGroup from "@/components/molecules/ContactGroup";
+import Section from "@/components/organisms/layouts/Section";
+
+const IntroductionSection = () => {
+  return (
+    <Section>
+      <SlideAnimation offsetY={40} duration={0.5}>
+        <p className="text-center">
+          <Display1 text="안녕하세요" />
+          <br />
+          <Display1 text="개발자 " />
+          <Display1 text="이재윤" styles={{ color: "text-primary-600" }} />
+          <Display1 text="입니다" />
+        </p>
+      </SlideAnimation>
+
+      <SlideAnimation offsetY={-20} delay={1}>
+        <div className="flex flex-col justify-center items-center w-full gap-y-8">
+          <p className="text-center">
+            <Title1 text="Frontend " styles={{ color: "text-primary-600" }} />
+            <Title1 text="Developer" styles={{ color: "text-gray-400" }} />
+            <br />
+            <Title1 text="Mobile App " styles={{ color: "text-primary-600" }} />
+            <Title1 text="Developer" styles={{ color: "text-gray-400" }} />
+          </p>
+
+          <p className="text-center">
+            <Heading1 text="사용자의 입장에서 더 나은 경험을 고민하고," styles={{ color: "text-gray-400" }} />
+            <br />
+            <Heading1 text="기술에 대한 열정을 양분삼는 개발자입니다." styles={{ color: "text-gray-400" }} />
+          </p>
+
+          <ContactGroup />
+        </div>
+      </SlideAnimation>
+    </Section>
+  );
+};
+
+export default IntroductionSection;

--- a/src/components/organisms/layouts/Section.tsx
+++ b/src/components/organisms/layouts/Section.tsx
@@ -1,0 +1,11 @@
+import { ReactNode } from "react";
+
+interface SectionProps {
+  children?: ReactNode;
+}
+
+const Section = ({ children }: SectionProps) => {
+  return <section className="flex flex-col justify-center items-center w-full py-36 gap-y-8">{children}</section>;
+};
+
+export default Section;

--- a/src/providers/ToastProvider.tsx
+++ b/src/providers/ToastProvider.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { ToastContainer } from "react-toastify";
+
+const ToastProvider = () => {
+  return <ToastContainer position="top-right" autoClose={3000} />;
+};
+
+export default ToastProvider;

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -106,6 +106,11 @@
     line-height: 1;
   }
 
+  p {
+    word-break: keep-all;
+    white-space: pre-line;
+  }
+
   ol,
   ul {
     list-style: none;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -20,6 +20,8 @@
 
   --black: #18181b;
 
+  --toastify-color-success: #3a5afe;
+
   /* ============ 폰트 패밀리 변수 ============ */
   --geist-sans: Arial, Helvetica, sans-serif;
   --geist-mono: monospace;


### PR DESCRIPTION
## 🛠️ 작업 내용

1. 슬라이드 애니메이션 추가
   - framer-motion 사용
   - 슬라이드 애니메이션 구현
   -src/components/animations 디렉토리에 애니메이션 정리

2. 토스트 메세지 추가
   - react-toastify 사용
   - RootLayout에 ToastProvider 등록
   - 연락처 클립보드 복사 시 토스트 메세지 출력
   - 토스트 강조 색상은 src/styles/variables.css에 --toastify-color-success 변수로 정의
   
3. 자기소개 데이터 추가
   - 정적 데이터 작성
   - 전화번호, 이메일은 토글 형태로 노출, 클립보드 복사 가능
   - 깃허브는 링크를 통해 리다이렉트