### PR TITLE
[Fix] 스크롤 인디케이터 x축 위치 조정

### DIFF
--- a/src/components/atoms/ScrollIndicator.tsx
+++ b/src/components/atoms/ScrollIndicator.tsx
@@ -9,16 +9,21 @@ interface ScrollIndicatorProps {
 
 const ScrollIndicator = ({ duration = 1, delay }: ScrollIndicatorProps) => {
   return (
-    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration, delay }} className="absolute bottom-8 left-1/2">
+    <motion.div
+      className="absolute bottom-8 left-1/2 translate -translate-x-1/2"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration, delay }}
+    >
       <motion.div
+        className="flex justify-center w-6 h-10 border-2 rounded-full border-gray-400"
         animate={{ y: [0, 10, 0] }}
         transition={{ duration: duration * 1.5, repeat: Infinity }}
-        className="flex justify-center w-6 h-10 border-2 rounded-full border-gray-400"
       >
         <motion.div
+          className="w-1 h-3 mt-2 rounded-full bg-gray-400"
           animate={{ y: [0, 12, 0] }}
           transition={{ duration: duration * 1.5, repeat: Infinity }}
-          className="w-1 h-3 mt-2 rounded-full bg-gray-400"
         />
       </motion.div>
     </motion.div>


### PR DESCRIPTION
## 🛠️ 작업 내용

1. 스크롤 인디케이터 화면 가운데 위치로 조정
   - translate,  -translate-x-1/2 속성 추가
 

   
